### PR TITLE
Bump Spring Boot starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.5</version>
+		<version>2.5.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,7 +3,7 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=pw
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-
+spring.jpa.defer-datasource-initialization: true
 
 omopfhir.caresite.name=myCareSite
 omopfhir.provider.name=myProvider


### PR DESCRIPTION
This bump the Spring Boot starter and fixes #10.

The reason for the test failures is that the `data.sql` script are run before Hibernate is initialized (and the DB created). See [Spring Boot 2.5 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#hibernate-and-datasql).